### PR TITLE
Update blank_template.py to fix Attribute Error

### DIFF
--- a/blank_template/blank_template.py
+++ b/blank_template/blank_template.py
@@ -14,8 +14,9 @@ class State(rx.State):
 
 
 def index() -> rx.Component:
+    # Welcome Page (Index)
     return rx.fragment(
-        rx.color_mode_button(rx.color_mode_icon(), float="right"),
+        rx.color_mode.button(rx.color_mode.icon(), float="right"),
         rx.vstack(
             rx.heading("Welcome to Reflex!", font_size="2em"),
             rx.box("Get started by editing ", rx.code(filename, font_size="1em")),
@@ -32,7 +33,7 @@ def index() -> rx.Component:
                     )
                 },
             ),
-            spacing="1.5em",
+            spacing="1",
             font_size="2em",
             padding_top="10%",
         ),


### PR DESCRIPTION
Previous configuration would give a :
...
.venv/lib/python3.12/site-packages/reflex/__init__.py", line 231, in __getattr__
    raise AttributeError(f"module 'reflex' has no attribute {name}") from None
AttributeError: module 'reflex' has no attribute reflex.color_mode_button

Also, "spacing" (line 36) would not accept anything but an integer for a value. It has been updated to 1 in this commit vs .5em in the previous one.



Updated